### PR TITLE
Token expiry and json

### DIFF
--- a/gcloud.opam
+++ b/gcloud.opam
@@ -26,6 +26,7 @@ depends: [
   "ppx_here" {test}
   "ptime" {test}
   "sexplib" {< "v0.11.0"}
+  "ssl" {= "0.5.5"}
   "x509"
   "yojson"
 ]

--- a/gcloud.opam
+++ b/gcloud.opam
@@ -25,6 +25,7 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_here" {test}
   "ptime" {test}
+  "sexplib" {< "v0.11.0"}
   "x509"
   "yojson"
 ]

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -395,7 +395,7 @@ let get_access_token ?(scopes : string list = []) () : (token_info, error) Lwt_r
     }
   in
   let has_requested_scopes token_info = CCList.subset ~eq:String.equal scopes token_info.scopes in
-  let is_expired token_info = Unix.time () > token_info.created_at +. (float_of_int token_info.token.expires_in) in
+  let is_expired token_info = Unix.time () > (token_info.created_at +. (float_of_int token_info.token.expires_in) -. 30.) in
   let open Lwt.Infix in
   Lwt_mvar.take token_info_mvar >>= begin function
     | Some token_info when has_requested_scopes token_info && not (is_expired token_info) ->


### PR DESCRIPTION
- Fix sexplib for nocrypto pin and ssl for SSL error
- Try to print non-json bodies. Currently relying on JSON parse failure to detect this which isn't ideal but should do for now
- Add 30s offset to token expiration to see if it helps with the race