### PR TITLE
Bump x509

### DIFF
--- a/gcloud.opam
+++ b/gcloud.opam
@@ -24,6 +24,6 @@ depends: [
   "ppx_deriving_yojson"
   "ppx_here" {test}
   "ssl"
-  "x509" { >= "0.11.2" } # Required for the ~sloppy arg
+  "x509" { >= "0.12.0" } # Required for the ~sloppy:true arg becoming the default
   "yojson"
 ]

--- a/gcloud.opam
+++ b/gcloud.opam
@@ -22,6 +22,7 @@ depends: [
   "lwt"
   "ppx_deriving_yojson"
   "ppx_here" {test}
+  "tls" {test}
   "x509" { >= "0.12.0" } # Required for the ~sloppy:true arg becoming the default
   "yojson"
 ]

--- a/gcloud.opam
+++ b/gcloud.opam
@@ -23,7 +23,6 @@ depends: [
   "lwt_ssl"
   "ppx_deriving_yojson"
   "ppx_here" {test}
-  "ssl"
   "x509" { >= "0.12.0" } # Required for the ~sloppy:true arg becoming the default
   "yojson"
 ]

--- a/gcloud.opam
+++ b/gcloud.opam
@@ -20,7 +20,6 @@ depends: [
   "jose"
   "logs"
   "lwt"
-  "lwt_ssl"
   "ppx_deriving_yojson"
   "ppx_here" {test}
   "x509" { >= "0.12.0" } # Required for the ~sloppy:true arg becoming the default

--- a/src/auth.ml
+++ b/src/auth.ml
@@ -315,10 +315,6 @@ let access_token_of_credentials
         let now = Unix.time () in
         Cstruct.of_string c.private_key
         |> X509.Private_key.decode_pem
-           (* Some Gcloud RSA private keys have an invalid [d]. [sloppy:true]
-              will re-create the key from the primes [e], [p] and [q] if that is
-              the case. *)
-             ~sloppy:true
         |> CCResult.map_err (function `Msg msg -> `Bad_credentials_priv_key msg)
         |> Lwt.return
         >>= fun (`RSA priv_key) ->


### PR DESCRIPTION
Allow newer versions of x509, and remove dep on `ssl` - I made tls {test} only as i think cohttp works with either ssl or tls and this lets the consumer decide - if you have neither then it complains at runtime that it wasnt compiled with tls support.